### PR TITLE
Remove support library and disable jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,4 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 

--- a/xml-to-pdf/build.gradle
+++ b/xml-to-pdf/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.android.support:multidex:1.0.3'
     implementation 'com.karumi:dexter:6.2.2'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'


### PR DESCRIPTION
This PR remove the multidex support library and disable jetifier in order to all projects that depends of this library can remove jetifier too.

Jetifier decreases compile time and to disable it all dependencies need to get rid of support library.

Thanks for this library it helps so much. 