### PR TITLE
Removes Dexter & handles permissions

### DIFF
--- a/xml-to-pdf/build.gradle
+++ b/xml-to-pdf/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.karumi:dexter:6.2.2'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'

--- a/xml-to-pdf/src/main/java/com/gkemon/XMLtoPDF/PdfGenerator.java
+++ b/xml-to-pdf/src/main/java/com/gkemon/XMLtoPDF/PdfGenerator.java
@@ -23,6 +23,7 @@ import androidx.annotation.IdRes;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.lifecycle.DefaultLifecycleObserver;
@@ -30,13 +31,6 @@ import androidx.lifecycle.LifecycleOwner;
 
 import com.gkemon.XMLtoPDF.model.FailureResponse;
 import com.gkemon.XMLtoPDF.model.SuccessResponse;
-import com.karumi.dexter.Dexter;
-import com.karumi.dexter.MultiplePermissionsReport;
-import com.karumi.dexter.PermissionToken;
-import com.karumi.dexter.listener.PermissionDeniedResponse;
-import com.karumi.dexter.listener.PermissionGrantedResponse;
-import com.karumi.dexter.listener.PermissionRequest;
-import com.karumi.dexter.listener.multi.MultiplePermissionsListener;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -187,6 +181,7 @@ public class PdfGenerator {
         private String directoryPath;
         private Disposable disposable;
         private XmlToPDFLifecycleObserver xmlToPDFLifecycleObserver;
+        private final int PERMISSION_REQ_CODE = 100;
 
         private void postFailure(String errorMessage) {
             FailureResponse failureResponse = new FailureResponse(errorMessage);
@@ -558,37 +553,15 @@ public class PdfGenerator {
                             " Permission taking popup (using https://github.com/Karumi/Dexter) is going " +
                             "to be shown");
                 }
-                Dexter.withContext(context)
-                        .withPermissions(Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                                Manifest.permission.READ_EXTERNAL_STORAGE)
-                        .withListener(new MultiplePermissionsListener() {
-                            @Override
-                            public void onPermissionsChecked(MultiplePermissionsReport multiplePermissionsReport) {
 
-                                for (PermissionDeniedResponse deniedResponse :
-                                        multiplePermissionsReport.getDeniedPermissionResponses()) {
-                                    postLog("Denied permission: " + deniedResponse.getPermissionName());
-                                }
-                                for (PermissionGrantedResponse grantedResponse :
-                                        multiplePermissionsReport.getGrantedPermissionResponses()) {
-                                    postLog("Granted permission: " + grantedResponse.getPermissionName());
-                                }
-                                if (multiplePermissionsReport.areAllPermissionsGranted()) {
-                                    print();
-                                } else
-                                    postLog("All necessary permission is not granted by user. Please do that first");
-
-                            }
-
-                            @Override
-                            public void onPermissionRationaleShouldBeShown(List<PermissionRequest> list, PermissionToken permissionToken) {
-
-                            }
-                        })
-                        .withErrorListener(error -> postLog("Error from Dexter " +
-                                "(https://github.com/Karumi/Dexter) but this library is not maintaining " +
-                                "anymore so please look at this issue - https://github.com/Gkemon/Android-XML-to-PDF-Generator/issues/54#issuecomment-1550307371 " +
-                                error.toString())).check();
+                ActivityCompat.requestPermissions(
+                        (Activity) context,
+                        new String[]{
+                                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                                Manifest.permission.READ_EXTERNAL_STORAGE
+                        },
+                        PERMISSION_REQ_CODE
+                );
             }
 
         }


### PR DESCRIPTION
Fixes #54

- Removed the unmaintained dexter library and handles permissions.
- Tested on android 12 (API 33).

Note: Testing the changes is highly encouraged before merging the pull request